### PR TITLE
Only wait as long as necessary for DB

### DIFF
--- a/mssql-startup/docker-db-init.sh
+++ b/mssql-startup/docker-db-init.sh
@@ -1,6 +1,3 @@
-#wait for the SQL Server to come up
-sleep 90s
-
 echo "running set up script"
 #run the setup script to create the DB and the schema in the DB
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P mssqlPassw0rd! -d master -i db-init.sql
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P mssqlPassw0rd! -d master -l 90 -i db-init.sql


### PR DESCRIPTION
Remove `sleep 90` and instead allow 90s connection timeout on `sqlcmd`

(see docs for [sqlcmd](https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility?view=sql-server-2017))